### PR TITLE
Bump Bosch BMP5 SensorAPI lib to v1.1.1 to fix bugs in calculation fu…

### DIFF
--- a/src/bmp5_api/LICENSE
+++ b/src/bmp5_api/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2021 Bosch Sensortec GmbH. All rights reserved.
+Copyright (c) 2022 Bosch Sensortec GmbH. All rights reserved.
 
 BSD-3-Clause
 

--- a/src/bmp5_api/bmp5.h
+++ b/src/bmp5_api/bmp5.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2021 Bosch Sensortec GmbH. All rights reserved.
+* Copyright (c) 2022 Bosch Sensortec GmbH. All rights reserved.
 *
 * BSD-3-Clause
 *
@@ -31,8 +31,8 @@
 * POSSIBILITY OF SUCH DAMAGE.
 *
 * @file       bmp5.h
-* @date       2021-08-27
-* @version    v1.0.5
+* @date       2022-08-11
+* @version    v1.1.1
 *
 */
 

--- a/src/bmp5_api/bmp5_defs.h
+++ b/src/bmp5_api/bmp5_defs.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2021 Bosch Sensortec GmbH. All rights reserved.
+* Copyright (c) 2022 Bosch Sensortec GmbH. All rights reserved.
 *
 * BSD-3-Clause
 *
@@ -31,8 +31,8 @@
 * POSSIBILITY OF SUCH DAMAGE.
 *
 * @file       bmp5_defs.h
-* @date       2021-08-27
-* @version    v1.0.5
+* @date       2022-08-11
+* @version    v1.1.1
 *
 */
 
@@ -195,7 +195,8 @@
 #define BMP5_GET_BITS_POS_0(reg_data, bitname)    (reg_data & (bitname##_MSK))
 
 /*! @name Chip id of BMP5 */
-#define BMP5_CHIP_ID                              UINT8_C(0x50)
+#define BMP5_CHIP_ID_PRIM                         UINT8_C(0x50)
+#define BMP5_CHIP_ID_SEC                          UINT8_C(0x51)
 
 /*! @name API success code */
 #define BMP5_OK                                   INT8_C(0)


### PR DESCRIPTION
…nctions and temperature compensation

This just pulls in the latest source code from the [BMP5_SensorAPI library](https://github.com/boschsensortec/BMP5_SensorAPI/commits/master/), with the following commits:
- [c779b44 - Fixed a bug in the temperature compensation. Fixed typos and minor bugs.](https://github.com/boschsensortec/BMP5_SensorAPI/commit/c779b44bf3c682d1fc06b5771378361650028223)
- [f563c08 - Fixed a bug in the calculation functions. Added support for additional BMP5 variants.](https://github.com/boschsensortec/BMP5_SensorAPI/commit/f563c082cbe0267f0d9d76a52bf8bcd3a2b32b7a)